### PR TITLE
Add og:image hints to page templates.

### DIFF
--- a/_layouts/front.html
+++ b/_layouts/front.html
@@ -3,6 +3,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta property="og:image" content="/asset/TAG-logo.png" />
     <title>{{ page.title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="/bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,6 +3,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta property="og:image" content="/asset/TAG-logo.png" />
     <title>{{ page.title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="/bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
As a (potentially unwanted) side effect, this somewhat breaks cases where we intend to show and images from whatever content is in the page, but since we aren't using pretty pictures to increase conversion rate I think it is safe to let this one slide.

I actually do not know how one would do conditional og:images in a pretty way (e.g. show intended content image if there is one, otherwise show tag logo) in whatever preprocessor we used here.