### PR TITLE
Remove outdated note about Intersection Observer explainer

### DIFF
--- a/explainers.md
+++ b/explainers.md
@@ -29,7 +29,7 @@ the explainer can then provide a basis for author-facing documentation of the ne
 - [Web Share](https://github.com/WICG/web-share/blob/master/docs/explainer.md)
 - [Viewport API](https://github.com/WICG/ViewportAPI/blob/gh-pages/README.md)
 - [`EventListenerOptions`](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md)
-- [Intersection Observer](https://github.com/w3c/IntersectionObserver/blob/master/explainer.md) (although this one includes IDL, which explainers should not)
+- [Intersection Observer](https://github.com/w3c/IntersectionObserver/blob/master/explainer.md)
 
 ## Tips for effective explainers:
 


### PR DESCRIPTION
IDL was removed in https://github.com/w3c/IntersectionObserver/pull/199