### PR TITLE
Add doctoc comments to sample explainer.

### DIFF
--- a/explainers.md
+++ b/explainers.md
@@ -75,6 +75,9 @@ you should always try to keep your explainer as brief and easy to read as possib
 
 [You can generate a Table of Contents for markdown documents using a tool like [doctoc](https://github.com/thlorenz/doctoc).]
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Introduction
 
 [The "executive summary" or "abstract".


### PR DESCRIPTION
This way, if someone who uses doctoc writes a new explainer by coping our sample explainer, their autogenerated table of contents will land in the right place in their explainer.