### PR TITLE
Add Declarative Shadow DOM to list of good explainers.

### DIFF
--- a/explainers.md
+++ b/explainers.md
@@ -30,6 +30,7 @@ the explainer can then provide a basis for author-facing documentation of the ne
 - [Viewport API](https://github.com/WICG/ViewportAPI/blob/gh-pages/README.md)
 - [`EventListenerOptions`](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md)
 - [Intersection Observer](https://github.com/w3c/IntersectionObserver/blob/master/explainer.md)
+- [Declarative Shadow DOM](https://github.com/mfreed7/declarative-shadow-dom/blob/master/README.md)
 
 ## Tips for effective explainers:
 


### PR DESCRIPTION
@alice suggested in today's breakout B that the Declarative Shadow DOM
explainer is a good explainer and should be added to the list of good
explainers.  I agree with this suggestion, so here's a PR adding it.

(Note that saying the explainer being good isn't necessarily saying that
I like the feature.  I think I still disagree with the tradeoffs made
here... however, I agree that the explainer does a good job of
explaining the feature and it makes sense to link to it.)